### PR TITLE
Fix completed tasks in GTasks

### DIFF
--- a/GTasks_init.gs
+++ b/GTasks_init.gs
@@ -1,5 +1,6 @@
 const gtasksOptionalArgs = {
-    'maxResults': scriptProperties.getProperty("gtasks_maxresults")
+    'maxResults': scriptProperties.getProperty("gtasks_maxresults"),
+    'showHidden':true
 };
 let gtasksListCompleted = [];
 let gtasksListNotCompleted = [];


### PR DESCRIPTION
add showHidden true to the gtasks options because without it completed tasks wil not be returned by Tasks.Tasks.list() wich causes the script to not identify completed tasks correctly